### PR TITLE
Fix typo in playbooks_tests.rst

### DIFF
--- a/docsite/rst/playbooks_tests.rst
+++ b/docsite/rst/playbooks_tests.rst
@@ -24,7 +24,7 @@ To match strings against a substring or a regex, use the "match" or "search" fil
       url: "http://example.com/users/foo/resources/bar"
 
     tasks:
-        - shell: "msg='matched pattern 1'"
+        - debug: "msg='matched pattern 1'"
           when: url | match("http://example.com/users/.*/resources/.*")
 
         - debug: "msg='matched pattern 2'"


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
docsite/rst/playbooks_tests.rst
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3.0
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
the playbook "Jinja2 tests" documentation  was using "shell" task instead of "debug" task  
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```

shell task was used instead of debug